### PR TITLE
Remove race condition from acceptance test

### DIFF
--- a/src/NServiceBus.Wcf.AcceptanceTests/When_cancelling_request.cs
+++ b/src/NServiceBus.Wcf.AcceptanceTests/When_cancelling_request.cs
@@ -34,13 +34,11 @@ public class When_cancelling_request : NServiceBusAcceptanceTest
             .Run(TimeSpan.FromSeconds(10));
 
         Assert.That(context.Exception.Message, Does.Contain("The request was cancelled after"));
-        Assert.IsFalse(context.HandlerCalled);
         Assert.IsNull(context.Id);
     }
 
     class Context : ScenarioContext
     {
-        public bool HandlerCalled { get; set; }
         public FaultException Exception { get; set; }
         public Guid? Id { get; set; }
     }
@@ -65,11 +63,8 @@ public class When_cancelling_request : NServiceBusAcceptanceTest
 
         public class MyMessageHandler : IHandleMessages<MyMessage>
         {
-            public Context Context { get; set; }
-
             public Task Handle(MyMessage message, IMessageHandlerContext context)
             {
-                Context.HandlerCalled = true;
                 return context.Reply(new MyResponse
                 {
                     Id = message.Id


### PR DESCRIPTION
A certain test has repeatedly failed the build due to a failing assertion: https://builds.particular.net/viewLog.html?buildId=321495&tab=buildResultsDiv&buildTypeId=NServiceBus_Hosts_NServiceBusWcf_31

There might be cases, where the pipeline invocation isn't prevented, resulting in the message handler being invoked. The client still gets the exception and no response, but the handler is invoked. That might be a very rare case in reality, but something which I think we cannot entirely prevent. Reading the test description, the handler invocation is secondary, as long as the client won't get a response once cancelled.

Thoughts @Particular/nservicebus-maintainers ?