### PR TITLE
WCF: CancellationToken & Core Alpha 910

### DIFF
--- a/src/NServiceBus.Wcf.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Wcf.AcceptanceTests/DefaultServer.cs
@@ -35,8 +35,7 @@ public class DefaultServer : IEndpointSetupTemplate
 
         var storageDir = Path.Combine(NServiceBusAcceptanceTest.StorageRootDir, NUnit.Framework.TestContext.CurrentContext.Test.ID);
 
-        configuration.UseTransport<LearningTransport>()
-            .StorageDirectory(storageDir);
+        configuration.UseTransport(new LearningTransport { StorageDirectory = storageDir });
 
         configuration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
 

--- a/src/NServiceBus.Wcf.AcceptanceTests/NServiceBus.Wcf.AcceptanceTests.csproj
+++ b/src/NServiceBus.Wcf.AcceptanceTests/NServiceBus.Wcf.AcceptanceTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.631" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.910" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Wcf.Tests/NServiceBus.Wcf.Tests.csproj
+++ b/src/NServiceBus.Wcf.Tests/NServiceBus.Wcf.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.631" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.910" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />

--- a/src/NServiceBus.Wcf/NServiceBus.Wcf.csproj
+++ b/src/NServiceBus.Wcf/NServiceBus.Wcf.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.631,9.0.0)" />
-    <PackageReference Include="NServiceBus.Callbacks" Version="[4.0.0-alpha.98,5.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.910,9.0.0)" />
+    <PackageReference Include="NServiceBus.Callbacks" Version="[4.0.0-alpha.127,5.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Wcf/WcfSupport.cs
+++ b/src/NServiceBus.Wcf/WcfSupport.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.ServiceModel;
+    using System.Threading;
     using System.Threading.Tasks;
     using Hosting.Wcf;
 
@@ -44,12 +45,12 @@
                 this.wcfManager = wcfManager;
             }
 
-            protected override Task OnStart(IMessageSession session)
+            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
             {
                 return wcfManager.Startup(session);
             }
 
-            protected override Task OnStop(IMessageSession session)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
             {
                 return wcfManager.Shutdown();
             }


### PR DESCRIPTION
Decided with Adam and Daniel to leave the existing cancellation token support via an endpoint-configured timeout intact. As WCF is .NET Framework only, it doesn't make sense to make a breaking change that will affect the OperationContract when this is likely to be the last major version of this package.