### PR TITLE
Update README with NSB 8 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # NServiceBus.Wcf
 
 Enables simple hosting of WCF services which bridge between WCF and the messaging infrastructure.
+
+## Prerequisites
+
+NServiceBus.Wcf requires the .NET Framework and can only be used with NServiceBus 8 and below.


### PR DESCRIPTION
This PR adds a note to the README that should explain why there won't be an NSB 9 version.